### PR TITLE
Fix: Google Analytics configuration for Chirpy theme v7.2.4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,11 +36,14 @@ google_site_verification: # fill in to your verification string
 # ↑ --------------------------
 # The end of `jekyll-seo-tag` settings
 
-google_analytics:
-  id: G-9J3YRPN8EN
+# Analytics configuration
+analytics:
+  google:
+    id: G-9J3YRPN8EN
 
+# Google Tag Manager configuration
 google_tag_manager:
-  id: GTM-592PS4S2
+  container_id: GTM-592PS4S2
 
 # Prefer color scheme setting.
 #


### PR DESCRIPTION
## Description
This PR fixes the Google Analytics tracking configuration that wasn't working with the Chirpy theme v7.2.4.

## Changes Made
- Updated Google Analytics configuration from `google_analytics.id` to `analytics.google.id` format
- Changed Google Tag Manager configuration to use `container_id` instead of `id`
- Configuration now follows the Chirpy theme's expected format

## Testing
- Built site locally with `JEKYLL_ENV=production`
- Verified GA4 tracking script (G-9J3YRPN8EN) is now properly injected in HTML
- Confirmed GTM script (GTM-592PS4S2) configuration is updated

## Impact
Once merged and deployed:
- Google Analytics will start tracking visitor data
- Both rafaelvzago.github.io and www.rafaelvzago.com domains will be tracked
- Real-time analytics will be available in GA4 dashboard

## Checklist
- [x] Configuration follows Chirpy theme documentation
- [x] Tested locally with production environment
- [x] GA4 script verified in generated HTML
- [x] No linting errors introduced