### PR TITLE
chore: Update Chirpy theme to v7.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jekyll-theme-chirpy"
+gem "jekyll-theme-chirpy", "~> 7.3"
 
 group :test do
   gem "html-proofer", "~> 4.4"


### PR DESCRIPTION
## 📦 Update Summary

This PR updates the Jekyll Chirpy theme from v7.2.4 to v7.3.1.

### 🔄 Changes Made

- Updated `jekyll-theme-chirpy` gem from 7.2.4 to 7.3.1
- Added version constraint `~> 7.3` in Gemfile for better dependency management
- Updated all related dependencies for compatibility

### 📊 Updated Dependencies

| Package | Previous | New |
|---------|----------|-----|
| jekyll-theme-chirpy | 7.2.4 | 7.3.1 |
| rouge | 4.5.2 | 4.6.0 |
| sass-embedded | 1.87.0 | 1.92.1 |
| google-protobuf | 4.30.2 | 4.32.1 |
| nokogiri | 1.18.8 | 1.18.10 |
| Other minor dependency updates | | |

### ✅ Testing

- [x] Built site locally without errors
- [x] Tested Jekyll server locally
- [x] Verified all pages load correctly
- [x] Confirmed RSS feed and sitemap generation
- [x] All existing functionality preserved

### 🎯 Benefits

- Performance improvements from Chirpy 7.3.x
- Bug fixes and stability improvements
- Updated dependencies for better security
- Maintains full compatibility with existing content

### 📝 Notes

- Gemfile.lock is gitignored (as intended for gem-based themes)
- Only Gemfile needs to be committed
- GitHub Pages will use the specified version when building

---
**No breaking changes expected. Safe to merge.**