### PR TITLE
docs(agents): bootstrap agentic SDLC playbook

### DIFF
--- a/.cursor/rules/agentic-sdlc.mdc
+++ b/.cursor/rules/agentic-sdlc.mdc
@@ -1,0 +1,16 @@
+---
+description: Follow docs/agents/sdlc.md as the default Cursor/Claude development process
+alwaysApply: true
+---
+
+# Follow the project agentic SDLC
+
+At session start, read and follow `docs/agents/sdlc.md`.
+
+- Prefer remote `main` over a stale local clone or memory.
+- Do not invent a parallel SDLC.
+- Skills live at user level (`~/.cursor/skills/` / `~/.claude/skills/`); read the skill before using it; do not vendor skill bodies into this repo.
+- Tracker binding: `docs/agents/issue-tracker.md`.
+- Root `AGENTS.md` / `CLAUDE.md` are commands and domain only — they do **not** override `docs/agents/sdlc.md`.
+
+Flow in order: clarify (`batch-grill-me`) → spec (`to-spec`) → tickets (`to-tickets`) → implement loop with local preview → ship only after human approval.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ package-lock.json
 # Misc
 assets/js/dist
 .aider*
+.claude/settings.local.json
+.scratch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,119 @@
+# AGENTS.md
+
+Regras comportamentais e invariantes para todos os agentes que operam neste repositorio.
+
+**Processo (SDLC):** ver [`docs/agents/sdlc.md`](docs/agents/sdlc.md). Este arquivo e `CLAUDE.md` cobrem comandos e dominio; nao sobrescrevem o playbook.
+
+## Comandos de Setup
+
+```bash
+bundle exec jekyll serve          # servidor de desenvolvimento
+bundle exec jekyll serve --drafts # incluindo rascunhos
+bundle exec jekyll build          # build para producao
+bundle exec htmlproofer ./_site   # validacao HTML
+```
+
+## Regras Globais
+
+1. Todo conteudo novo deve ser escrito em portugues (pt-BR) com acentuacao correta, salvo quando o usuario pedir explicitamente em ingles.
+2. Nunca fazer push direto em `main`. Push de feature branch / PR so apos preview local e aprovacao humana (ver `docs/agents/sdlc.md` §5). Fora do passo Ship, nao executar `git push`.
+3. Nunca modificar arquivos protegidos: `_config.yml`, `LICENSE`, `Gemfile`, `Gemfile.lock`.
+4. Nunca modificar arquivos em `_plugins/` a menos que explicitamente solicitado.
+5. Nunca usar `git add .` ou `git add -A`. Sempre adicionar arquivos individualmente.
+6. Posts devem usar `##` como heading de nivel mais alto (Chirpy renderiza o titulo do frontmatter como `<h1>`).
+7. Nunca criar posts com datas no futuro alem de 7 dias.
+8. Slugs de posts devem ser lowercase, sem acentos, separados por hifens.
+
+## Formato Canonico de Frontmatter
+
+Todo post novo deve seguir exatamente este formato:
+
+```yaml
+---
+layout: post
+title: "Titulo do Post em Portugues"
+description: "Descricao para SEO com 150-160 caracteres"
+date: YYYY-MM-DD
+categories: [Categoria1, Categoria2]
+tags: [tag1, tag2, tag3]
+image:
+  path: /assets/img/headers/nome-do-arquivo.ext
+  alt: Descricao da imagem
+---
+```
+
+Campos obrigatorios para posts novos: `layout`, `title`, `description`, `date`, `categories`, `tags`, `image.path`, `image.alt`.
+
+Para posts existentes (pre-2025) que nao possuem `description`, o Reviewer deve emitir WARNING, nao ERROR.
+
+## Registro de Categorias Aprovadas
+
+```
+AI, carreira, chatbot, CI/CD, cloud, DevOps, english, grafana,
+instructlab, Internet, Istio, Jenkins, k8s, Kubernetes, linux,
+MLOps, multi, network, networking, off-topic, OpenShift, opensource,
+pipeline, productivity, raspberry, redhat, rtos, Service Mesh,
+skupper, Skupper, sobre, tcpip, tecnologia, vim
+```
+
+Novas categorias podem ser adicionadas, mas o agente deve sinalizar para confirmacao do usuario.
+
+## Registro de Tags Aprovadas
+
+```
+ai, ambient-mode, architecture, arpanet, automacao, casc, carreira,
+chatbot, ci-cd, cicd, cloud, contribuicao, database, deep-learning,
+deepseek, desenvolvimento, devops, editor, fraud-detection, gguf,
+gitops, gpt, grafana, hands-on, historia, hybrid-cloud, ingress,
+instructlab, insurance, instrutor, internet, iot, jenkins, kernel,
+kiali, kubernetes, licencas, linux, llama-cpp, llm, loadbalancer,
+local-ai, low-latency, machine-learning, migration, mlops,
+monitoring, motions, multicloud, networking, neovim, nginx,
+observability, openshift, opensource, palestrante, pessoal,
+pipeline, podman, preempt-rt, produtividade, prometheus, protocolos,
+rafael-zago, raspberry-pi, real-time, redes, redhat, rtos, security,
+service-mesh, sistemas-embarcados, skupper, software-livre, sobre,
+tcp-ip, tecnologia, temperature-sensor, tools, transformers,
+tutorial, upstream-downstream, vim, workshop
+```
+
+Novas tags podem ser adicionadas, mas o agente deve sinalizar para confirmacao do usuario.
+
+## Checagens Obrigatorias Pre-Commit
+
+Antes de qualquer commit, TODOS os checks abaixo devem passar:
+
+### 1. Validacao de Frontmatter
+
+Verificar que todos os campos obrigatorios estao presentes no frontmatter de posts novos ou modificados.
+
+### 2. Formato de Nome de Arquivo
+
+Nome do arquivo deve seguir `YYYY-MM-DD-slug.md`. A data no nome deve ser consistente com o campo `date:` do frontmatter.
+
+### 3. Referencia de Imagem
+
+O caminho em `image.path` deve corresponder a um arquivo existente em `assets/img/headers/`.
+
+### 4. Acentuacao Portuguesa
+
+Nenhuma palavra portuguesa comum deve aparecer sem acento no conteudo:
+
+```bash
+grep -inE '\b(codigo|voce|nao|tambem|alem|ate|pagina|unico|possivel|necessario|basico|metodo|titulo|topico|analise|numero|conteudo|seguranca|producao|informacao|aplicacao|integracao|solucao|funcao|execucao|configuracao|operacao|referencia|experiencia)\b' _posts/ARQUIVO.md
+```
+
+Se encontrar ocorrencias, reportar como ERROR.
+
+### 5. Categorias e Tags
+
+Comparar categorias e tags propostas contra os registros aprovados. Sinalizar valores novos para confirmacao.
+
+## Encadeamento de Subagentes
+
+Os agentes suportam encadeamento via Agent tool:
+- O Writer pode invocar o Reviewer como subagente apos criar um post.
+- O Reviewer pode ser invocado standalone ou como parte de um chain.
+- Cada skill verifica se foi invocado standalone ou como parte de um pipeline (via argumentos).
+
+Exemplo de chain: `/write-post kubernetes observability` -> Writer cria post -> spawna Reviewer -> Reviewer reporta findings inline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**Process (SDLC):** follow [`docs/agents/sdlc.md`](docs/agents/sdlc.md). This file and `AGENTS.md` cover commands and domain; they do not override the playbook.
+
 ## Project Overview
 
 This is Rafael Zago's personal blog built with Jekyll using the Chirpy theme. The site is written in Portuguese (pt-BR) and focuses on cloud, DevOps, infrastructure, automation, and AI-related topics. The site is deployed to GitHub Pages.
@@ -65,3 +67,17 @@ This is Rafael Zago's personal blog built with Jekyll using the Chirpy theme. Th
 ## Code Style
 
 - **Indentation**: Use 4 spaces for indentation (no tabs)
+
+## Agent System
+
+This repository uses a Claude Code agent system with specialized agents:
+
+- **Writer** (`/write-post`) -- Creates new blog posts following established patterns
+- **Reviewer** (`/review-post`) -- Reviews posts for quality, formatting, and SEO
+- **Content Analyst** (`/analyze-content`) -- Analyzes content gaps and suggests topics
+- **Committer** (`/commit`) -- Creates conventional commits with pre-commit checks
+
+Agents support subagent chaining (e.g., Writer can auto-spawn Reviewer after creating a post).
+
+See `AGENTS.md` for behavioral rules and invariants.
+See `.claude/agents/` for agent definitions, `.claude/skills/` for workflows, `.claude/commands/` for invocation.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,7 @@
+# Progress
+
+Tracking for agentic implement loops. Update when closing tickets (see `docs/agents/sdlc.md`).
+
+| Date | Ticket | Status | Notes |
+|------|--------|--------|-------|
+| — | — | — | Bootstrap only; no active PRD yet. |

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,25 @@
+# Domain docs
+
+How agents consume domain knowledge for this blog.
+
+## Primary sources
+
+| Doc | Role |
+|-----|------|
+| [`AGENTS.md`](../../AGENTS.md) | Content invariants: language, frontmatter, categories/tags, pre-commit checks, content-agent chaining |
+| [`CLAUDE.md`](../../CLAUDE.md) | Project overview, Jekyll commands, content structure, agent system overview |
+| [`.claude/agents/`](../../.claude/agents/) | Writer, Reviewer, Content Analyst, Committer definitions |
+| [`.claude/skills/`](../../.claude/skills/) | Content workflows (`write-post`, `review-post`, `analyze-content`, `commit`) |
+
+## Process vs domain
+
+- **Process** (grill → spec → tickets → implement → preview → ship): [`sdlc.md`](./sdlc.md). Wins on conflicts about *how* work is planned and shipped.
+- **Domain** (Portuguese content, Chirpy frontmatter, approved tags, protected files): `AGENTS.md` / `CLAUDE.md`. Wins on *what* valid blog content looks like.
+
+## Protected files (domain)
+
+Never modify unless the human explicitly requests: `_config.yml`, `LICENSE`, `Gemfile`, `Gemfile.lock`, and `_plugins/` (unless asked).
+
+## Language
+
+New content is pt-BR with correct accents, unless the human asks for English.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,42 @@
+# Issue tracker
+
+| Field | Value |
+|-------|-------|
+| Host | GitHub |
+| Repo | `rafaelvzago/rafaelvzago.github.io` |
+| Default branch | `main` |
+| CLI | `gh` |
+| Auth | `gh auth login` (user already authenticated in agent env when available) |
+
+## Conventions
+
+- PRDs and tickets are **GitHub Issues**.
+- Parent/child: link tickets to the PRD issue in the body (`Parent: #N`) and with `gh issue develop` / issue references as available.
+- Apply triage labels from [`triage-labels.md`](./triage-labels.md). Prefer `ready-for-agent` when a ticket is fully specified.
+- Local scratch copies (not source of truth):
+  - `.scratch/prd-<slug>.md`
+  - `.scratch/<slug>/issues/NN-<slug>.md`
+
+## Common commands
+
+```bash
+gh issue create --title "..." --body "$(cat <<'EOF'
+...
+EOF
+)" --label ready-for-agent
+
+gh issue list --label ready-for-agent
+gh issue view <N>
+gh issue close <N> --comment "Done in <sha / PR>"
+
+gh pr create --base main --title "..." --body "$(cat <<'EOF'
+...
+EOF
+)"
+```
+
+## Ship / push policy
+
+- Do **not** push to `main` directly.
+- Push feature branches and open PRs only after local preview approval (see [`sdlc.md`](./sdlc.md) §5).
+- Content-agent commits (Writer/Committer) still require an explicit human ask to commit; Ship/PR still requires preview approval.

--- a/docs/agents/sdlc.md
+++ b/docs/agents/sdlc.md
@@ -1,0 +1,140 @@
+# Agentic development playbook
+
+Canonical process for Cursor / Claude work in this repository.
+**Do not invent a parallel SDLC.** On conflicts, this file (on remote `main`) wins over local memory or a stale clone.
+
+Skills live at user level (`~/.cursor/skills/` / `~/.claude/skills/`).
+Read the skill file before using it. Do **not** vendor skill bodies into this repo.
+
+| Skill | When |
+|-------|------|
+| `batch-grill-me` | Design is open — frontier interview before locking decisions |
+| `to-spec` | Conversation → PRD → tracked issue |
+| `to-tickets` | PRD → vertical-slice tickets with blockers |
+| `implement` | Build one ticket |
+| `tdd` | Red-green at pre-agreed seams |
+| `code-review` | Standards + Spec review (HITL with the human) |
+| `handoff` | Compact context for a fresh agent |
+| `diagnosing-bugs` | Hard bugs / regressions |
+
+Tracker binding: [`issue-tracker.md`](./issue-tracker.md).
+Domain / content invariants: root [`AGENTS.md`](../../AGENTS.md) and [`domain.md`](./domain.md) — they do **not** override this playbook.
+
+---
+
+## When this playbook applies
+
+- **Full flow (grill → spec → tickets → implement):** non-trivial site work — theme/layout changes, plugins, automation, tooling, multi-file refactors, new features.
+- **Content agents (Writer / Reviewer / Content Analyst / Committer):** still valid for blog posts and content ops. They follow `AGENTS.md` + `.claude/` skills. If a post request expands into site/feature work, switch to this playbook.
+- **Trivial one-liners** (typo, single-line fix with clear acceptance): may skip grill/spec/tickets when the human explicitly waives process.
+
+---
+
+## Flow (in order)
+
+### 0. Source of truth
+
+Load these docs first. Prefer remote `main` over a stale local clone.
+
+- `docs/agents/sdlc.md` (this file)
+- `docs/agents/issue-tracker.md`, `triage-labels.md`, `domain.md`
+- Root `AGENTS.md` / `CLAUDE.md` — commands and domain only
+
+### 1. Clarify — `batch-grill-me`
+
+If design is ambiguous or has real trade-offs, grill round-by-round before locking.
+Prefer YAGNI / smallest correct change.
+
+### 2. Spec — `to-spec`
+
+Confirm testing seams with the user first. Publish a PRD as a tracked GitHub issue.
+Save a local copy under `.scratch/prd-<slug>.md`. Apply triage label `ready-for-agent`.
+
+PRD shape:
+
+- Problem Statement
+- Solution
+- User Stories
+- Implementation Decisions (modules/interfaces/API — no fragile file paths)
+- Testing Decisions (external behavior, seams, prior art)
+- Out of Scope
+- Further Notes
+
+### 3. Tickets — `to-tickets`
+
+Break the PRD into **tracer-bullet vertical slices**:
+
+- Narrow but complete path through every layer (content / Liquid / assets / CI / tests as applicable)
+- Demoable alone; sized for one fresh context window
+- Prefactors first; wide refactors use expand–contract
+
+Quiz the user on granularity and blockers, then publish each ticket as its own issue (parent = PRD).
+Local copies: `.scratch/<slug>/issues/NN-<slug>.md`. Apply triage label.
+Do **not** close or rewrite the parent PRD when publishing tickets.
+
+Every ticket body includes: What to build, Acceptance criteria, Blocked by.
+
+### 4. Implement loop (frontier = unblocked tickets)
+
+1. **Build** — `implement` + `tdd` at agreed seams only
+2. **Review** — show the diff to the human; run `code-review` (HITL)
+3. **Local preview (required)** — agent **starts** the preview server, gives the URL, **waits for explicit approval** before Ship. Reuse a healthy existing server when possible. Docs-only: show the diff and wait. Do **not** open a PR until they confirm.
+4. **Track** — update repo-root `PROGRESS.md`; close the ticket issue
+5. **Handoff** — at ~50% of tickets or end of a phase, run `handoff` → `/tmp/handoff-<slug>.md`
+6. **Next** — next unblocked ticket
+
+#### Local preview — agent must run the env
+
+1. Check existing terminals; reuse if already serving this site.
+2. Otherwise start the narrowest useful preview in the background, wait until ready, report the exact URL.
+3. Ask the human to review at that URL and **stop** until they approve or request changes.
+
+**Preview commands (this project):**
+
+```bash
+bundle exec jekyll serve          # http://localhost:4000
+bundle exec jekyll serve --drafts # including drafts
+bundle exec jekyll build          # production build
+bundle exec htmlproofer ./_site   # HTML validation after build
+```
+
+Hard rules:
+
+- Every ticket **must** be a tracker issue **before** coding starts
+- Never push directly to `main` — feature branch → PR → merge
+- **Never open a PR until the human has previewed locally and approved**
+- **Agent runs the preview env**; do not leave “run this yourself” as the default
+- If the user says proceed without approval between tickets, run the loop sequentially
+  (local preview still required before Ship unless they explicitly waive it)
+- Prefer the smallest correct change
+- Do not invent process; do not skip grill/spec/tickets for non-trivial work
+
+### 5. Ship
+
+Only after local preview approval:
+
+1. Open a PR against `main` (GitHub: `rafaelvzago/rafaelvzago.github.io`)
+2. Merge when asked
+3. Deploy path: GitHub Pages via the repo’s existing Pages/CI setup
+
+Post-merge checklist:
+
+- [ ] CI / Pages build succeeded
+- [ ] Expected revision is live at https://rafaelvzago.github.io
+- [ ] Smoke-check the change
+
+---
+
+## Tracker & triage
+
+See [`issue-tracker.md`](./issue-tracker.md) and [`triage-labels.md`](./triage-labels.md).
+
+Default roles:
+
+| Role | Meaning |
+|------|---------|
+| `needs-triage` | Maintainer must evaluate |
+| `needs-info` | Waiting on reporter |
+| `ready-for-agent` | Fully specified; AFK agent can implement |
+| `ready-for-human` | Needs human implementation |
+| `wontfix` | Will not be actioned |

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,22 @@
+# Triage labels
+
+Agentic triage roles for this repo. Create missing labels with `gh label create` if needed.
+
+| Label | Meaning | Color (suggested) |
+|-------|---------|-------------------|
+| `needs-triage` | Maintainer must evaluate | `#fbca04` |
+| `needs-info` | Waiting on reporter | `#d93f0b` |
+| `ready-for-agent` | Fully specified; AFK agent can implement | `#0e8a16` |
+| `ready-for-human` | Needs human implementation | `#1d76db` |
+| `wontfix` | Will not be actioned (GitHub default) | `#ffffff` |
+
+## Mapping from GitHub defaults
+
+| GitHub default | Use for |
+|----------------|---------|
+| `bug` | Defects (still apply a triage role) |
+| `enhancement` | Features (still apply a triage role) |
+| `documentation` | Docs-only work |
+| `question` | Often pairs with `needs-info` |
+
+Agents implementing work should only pick up issues labeled `ready-for-agent` unless the human explicitly assigns something else.


### PR DESCRIPTION
## Summary
- Add canonical agentic SDLC under `docs/agents/` (`sdlc.md`, tracker, triage labels, domain)
- Wire `AGENTS.md` / `CLAUDE.md` and an always-apply Cursor rule to that playbook
- Add `PROGRESS.md` and ignore `.scratch/` for local PRD/ticket copies

## Test plan
- [ ] Open `docs/agents/sdlc.md` and confirm preview commands match Jekyll (`bundle exec jekyll serve`)
- [ ] Confirm GitHub labels exist: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`
- [ ] Spot-check that `.gitignore` still ignores `Gemfile.lock`, `_site`, `.bundle` (only adds `.scratch/` + `.claude/settings.local.json`)


Made with [Cursor](https://cursor.com)