### PR TITLE
ci: skip pages deploy for non-site path changes

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -3,6 +3,21 @@ name: Build and deploy Jekyll site
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - '.claude/**'
+      - '.cursor/**'
+      - 'docs/**'
+      - '.scratch/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'PROGRESS.md'
+      - 'README.md'
+      - 'LICENSE'
+      - 'Makefile'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - '.tool-versions'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to the pages deploy workflow so pushes that only touch agent/docs/process files do not rebuild or redeploy the site
- Keep `workflow_dispatch` for manual deploys; mixed commits that include site paths still trigger the workflow

## Test plan
- [ ] Merge a commit that only changes an ignored path (e.g. `AGENTS.md`) and confirm "Build and deploy Jekyll site" does not run
- [ ] Merge or push a change under `_posts/` (or another non-ignored path) and confirm the workflow runs
- [ ] Confirm Actions → "Build and deploy Jekyll site" → Run workflow still works via `workflow_dispatch`


Made with [Cursor](https://cursor.com)