### PR TITLE
feat(theme): add back-to-top button on blog posts

### DIFF
--- a/assets/css/back-to-top.css
+++ b/assets/css/back-to-top.css
@@ -1,0 +1,46 @@
+.back-to-top {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 999px;
+  background: var(--color-primary, #dc143c);
+  color: #ffffff;
+  font: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(0.5rem);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.back-to-top.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.back-to-top:hover,
+.back-to-top:focus-visible {
+  filter: brightness(1.08);
+  outline: 2px solid var(--color-primary, #dc143c);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top {
+    transition: none;
+  }
+}

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -1,0 +1,25 @@
+(function () {
+  var btn = document.querySelector(".back-to-top");
+  if (!btn) {
+    return;
+  }
+
+  var threshold = 400;
+  var reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  function update() {
+    var y = window.scrollY || document.documentElement.scrollTop;
+    btn.classList.toggle("is-visible", y > threshold);
+  }
+
+  function goTop() {
+    window.scrollTo({
+      top: 0,
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+  }
+
+  btn.addEventListener("click", goTop);
+  window.addEventListener("scroll", update, { passive: true });
+  update();
+})();

--- a/hugo.toml
+++ b/hugo.toml
@@ -25,9 +25,9 @@ favicon = "/assets/img/favicons/favicon.ico"
 mathjax = false
 katex = false
 mainSections = ["posts"]
-customcss = ["css/post-layout.css", "css/copy-code.css", "css/image-lightbox.css"]
-customCSS = ["css/post-layout.css", "css/copy-code.css", "css/image-lightbox.css"]
-customJS = ["js/copy-code.js", "js/image-lightbox.js", "js/global-search.js"]
+customcss = ["css/post-layout.css", "css/copy-code.css", "css/image-lightbox.css", "css/back-to-top.css"]
+customCSS = ["css/post-layout.css", "css/copy-code.css", "css/image-lightbox.css", "css/back-to-top.css"]
+customJS = ["js/copy-code.js", "js/image-lightbox.js", "js/global-search.js", "js/back-to-top.js"]
 
 [params.gtm]
 id = "GTM-592PS4S2"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -51,3 +51,6 @@ other = "Loading search index..."
 
 [search_noscript]
 other = "Search requires JavaScript to load the index and filter results."
+
+[back_to_top]
+other = "Back to top"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -51,3 +51,6 @@ other = "Carregando índice de busca..."
 
 [search_noscript]
 other = "A busca precisa de JavaScript para carregar o índice e filtrar os resultados."
+
+[back_to_top]
+other = "Voltar ao topo"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -44,5 +44,8 @@
     {{- partial "disqus.html" . -}}
     {{- end -}}
   </article>
+  {{- if eq .Section "posts" -}}
+  <button type="button" class="back-to-top" aria-label="{{ i18n "back_to_top" }}" title="{{ i18n "back_to_top" }}">↑</button>
+  {{- end -}}
 </main>
 {{ end }}


### PR DESCRIPTION
Floating control appears after scroll on post pages only, with pt-BR/en labels and no new dependencies.