### PR TITLE
fix(theme): keep SVG diagrams visible in image lightbox

### DIFF
--- a/assets/css/image-lightbox.css
+++ b/assets/css/image-lightbox.css
@@ -59,6 +59,14 @@ article .body img[src$=".svg"],
   border-radius: 2px;
 }
 
+/* SVG as <img> collapses to ~0px with width/height:auto + max-height in Chromium */
+.image-lightbox__img[src$=".svg"],
+.image-lightbox__img[src*=".svg?"] {
+  width: min(96vw, 1200px);
+  height: auto;
+  max-height: 92vh;
+}
+
 .image-lightbox__close {
   position: fixed;
   top: 0.75rem;

--- a/static/assets/img/ossm-acm-multicluster/architecture.svg
+++ b/static/assets/img/ossm-acm-multicluster/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
   <title id="title">Arquitetura OpenShift Service Mesh multi-cluster com ACM</title>
   <desc id="desc">Um cluster hub executa ACM, Observatorium e Thanos. Dois clusters spoke executam primários Istio, conectados por gateways east-west e confiança mTLS compartilhada. Kiali, Perses e Tempo ficam no primeiro spoke.</desc>
   <defs>

--- a/static/assets/img/ossm-acm-multicluster/observability-flow.svg
+++ b/static/assets/img/ossm-acm-multicluster/observability-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 860" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="860" viewBox="0 0 1440 860" role="img" aria-labelledby="title desc">
   <title id="title">Fluxos de métricas, traces e alertas</title>
   <desc id="desc">Métricas dos dois spokes passam por User Workload Monitoring e ACM até Thanos. Perses e Kiali consultam Thanos. Traces do segundo spoke são encaminhados com mTLS ao coletor e Tempo no primeiro spoke. A métrica de saúde do Kiali pode ser avaliada localmente e no hub.</desc>
   <defs>

--- a/static/assets/img/ossm-acm-multicluster/traffic-flow.svg
+++ b/static/assets/img/ossm-acm-multicluster/traffic-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 720" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="720" viewBox="0 0 1440 720" role="img" aria-labelledby="title desc">
   <title id="title">Fluxo de tráfego entre clusters</title>
   <desc id="desc">Uma requisição parte do cliente no primeiro spoke, é resolvida pelo control plane local, cruza um gateway east-west com mTLS e chega ao workload no segundo spoke.</desc>
   <defs>


### PR DESCRIPTION
## Summary
- Fix Chromium collapsing SVG images to a tiny point inside the lightbox (`width/height: auto` + `max-height`).
- Set intrinsic `width`/`height` on the three OSSM multicluster SVG diagrams.

Fixes the modal on https://www.rafaelvzago.com/posts/openshift-service-mesh-3-multicluster-acm-kiali/ (e.g. architecture / traffic-flow SVGs).

## Test plan
- [ ] Open a diagram SVG in the lightbox — image fills the dialog, not a point
- [ ] PNG header image still opens correctly
- [ ] `make test`


Made with [Cursor](https://cursor.com)