### PR TITLE
feat: flag language switcher and llms.txt

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,11 +1,10 @@
 # Progress
 
-## Lang flags + llms.txt — IN PREVIEW
+## Lang flags + llms.txt — PR READY
 
 - Branch: `feat/lang-flags-llms-txt`
 - Language switcher uses BR/US SVG flags; `/llms.txt` published from `static/llms.txt`
-- Preview: http://127.0.0.1:1313/ · http://127.0.0.1:1313/en/ · http://127.0.0.1:1313/llms.txt
-- Awaiting local preview approval before Ship
+- Preview LGTM (local); opening PR for merge
 
 ## Hugo cutover + Jekyll rollback (PRD #33) — SHIPPED
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,12 @@
 # Progress
 
+## Lang flags + llms.txt — IN PREVIEW
+
+- Branch: `feat/lang-flags-llms-txt`
+- Language switcher uses BR/US SVG flags; `/llms.txt` published from `static/llms.txt`
+- Preview: http://127.0.0.1:1313/ · http://127.0.0.1:1313/en/ · http://127.0.0.1:1313/llms.txt
+- Awaiting local preview approval before Ship
+
 ## Hugo cutover + Jekyll rollback (PRD #33) — SHIPPED
 
 - Merged to `main` @ `734a380` (2026-07-24); preview LGTM

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,10 +1,10 @@
 # Progress
 
-## Lang flags + llms.txt — PR READY
+## Lang flags + llms.txt — PR OPEN
 
+- PR: https://github.com/rafaelvzago/rafaelvzago.github.io/pull/47
 - Branch: `feat/lang-flags-llms-txt`
 - Language switcher uses BR/US SVG flags; `/llms.txt` published from `static/llms.txt`
-- Preview LGTM (local); opening PR for merge
 
 ## Hugo cutover + Jekyll rollback (PRD #33) — SHIPPED
 

--- a/assets/css/post-layout.css
+++ b/assets/css/post-layout.css
@@ -21,8 +21,31 @@
   font-size: 0.9em;
 }
 
+.lang-switch__flag {
+  display: block;
+  width: 1.25em;
+  height: auto;
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 25%, transparent);
+}
+
 .lang-switch__current {
-  font-weight: 700;
+  display: inline-flex;
+  line-height: 0;
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.lang-switch__link {
+  display: inline-flex;
+  line-height: 0;
+  opacity: 0.85;
+}
+
+.lang-switch__link:hover,
+.lang-switch__link:focus-visible {
+  opacity: 1;
 }
 
 .lang-switch__sep {

--- a/layouts/partials/lang-switcher.html
+++ b/layouts/partials/lang-switcher.html
@@ -1,4 +1,5 @@
 {{- $page := . -}}
+{{- $flagByLang := dict "pt-br" "br.svg" "en" "us.svg" -}}
 <nav class="lang-switch" aria-label="{{ i18n "lang_switch" }}">
 	{{- range $idx, $lang := .Site.Languages -}}
 		{{- if $idx }}<span class="lang-switch__sep" aria-hidden="true">·</span>{{ end -}}
@@ -15,10 +16,15 @@
 				{{- end -}}
 			{{- end -}}
 		{{- end -}}
+		{{- $flag := index $flagByLang $lang.Lang -}}
 		{{- if eq $lang.Lang $page.Lang -}}
-			<span class="lang-switch__current" aria-current="true">{{ $lang.LanguageName }}</span>
+			<span class="lang-switch__current" aria-current="true" aria-label="{{ $lang.LanguageName }}">
+				<img class="lang-switch__flag" src="/assets/img/flags/{{ $flag }}" alt="" width="20" height="14" decoding="async">
+			</span>
 		{{- else -}}
-			<a class="lang-switch__link" href="{{ $href }}" hreflang="{{ $lang.Lang }}">{{ $lang.LanguageName }}</a>
+			<a class="lang-switch__link" href="{{ $href }}" hreflang="{{ $lang.Lang }}" aria-label="{{ $lang.LanguageName }}">
+				<img class="lang-switch__flag" src="/assets/img/flags/{{ $flag }}" alt="" width="20" height="14" decoding="async">
+			</a>
 		{{- end -}}
 	{{- end -}}
 </nav>

--- a/specs/site-core/spec.md
+++ b/specs/site-core/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Site Core Configuration
 
 **Created**: 2026-04-15
-**Updated**: 2026-07-23
+**Updated**: 2026-07-27
 **Status**: Baseline (Hugo)
 **Type**: Existing system documentation
 
@@ -21,6 +21,7 @@ A visitor arrives at the site (via search engine, direct link, or QR code) and r
 2. **Given** a published English post exists in `content/en/posts/`, **When** a visitor navigates to `/en/posts/<slug>/`, **Then** the English post renders
 3. **Given** the site is accessed on a mobile device, **When** the visitor reads a post, **Then** the layout is responsive and readable without horizontal scrolling
 4. **Given** a page has a translation sibling, **When** the visitor uses the language switcher, **Then** they land on the matching translation (otherwise the other language's home)
+5. **Given** the language switcher is visible, **When** the visitor views the navigation, **Then** each language is shown as a flag SVG (Brazil for `pt-br`, USA for `en`) with the language name available via `aria-label`
 
 ---
 
@@ -50,12 +51,14 @@ A visitor explores the site by clicking on tags to find related content.
 - **FR-001**: Site MUST use the Archie Hugo theme as a git submodule under `themes/archie`
 - **FR-002**: Site MUST be multilingual with default language `pt-br` at root URLs and `en` under `/en/`, timezone `America/Sao_Paulo`
 - **FR-002a**: Site MUST provide per-language menus/params and a language switcher in the navigation
+- **FR-002b**: Language switcher MUST use SVG flag icons (Brazil for `pt-br`, USA for `en`) instead of visible language names; language names MUST remain available via `aria-label`
 - **FR-003**: Site MUST include Google Analytics (`G-9J3YRPN8EN`) and Google Tag Manager (`GTM-592PS4S2`) on production builds (not during `hugo server`)
 - **FR-004**: Site MUST paginate the index at 10 posts per page
 - **FR-005**: Site MUST generate tag archive pages
 - **FR-006**: TOC SHOULD be available on posts via frontmatter `toc: true`
 - **FR-007**: Sub-sites (`static/qr/`, `static/amigo/`) MUST NOT appear in site navigation. They are accessed via direct URL only
 - **FR-008**: Site config lives in `hugo.toml`
+- **FR-009**: Site MUST publish `/llms.txt` (static Markdown index per llmstxt.org) with absolute HTTPS links to primary pages and feeds
 
 ### Key Entities
 
@@ -68,10 +71,12 @@ A visitor explores the site by clicking on tags to find related content.
 | Concern | File(s) |
 |---------|---------|
 | Theme & locale | `hugo.toml` |
+| Language switcher | `layouts/partials/lang-switcher.html`, `static/assets/img/flags/`, `assets/css/post-layout.css` |
+| LLM index | `static/llms.txt` → `/llms.txt` |
 | Analytics | `hugo.toml` (`services.googleAnalytics`, `params.gtm`) + `layouts/partials/gtm-*.html` |
 | Pagination | `hugo.toml` `[pagination]` |
 | Theme | `themes/archie` (submodule) |
-| About | `content/about.md` |
+| About | `content/pt-br/about.md`, `content/en/about.md` |
 
 ## Success Criteria
 
@@ -80,6 +85,7 @@ A visitor explores the site by clicking on tags to find related content.
 - **SC-001**: All pages render without Hugo build errors (exit code 0)
 - **SC-002**: Production HTML includes GA4 and GTM IDs
 - **SC-003**: `make test` succeeds
+- **SC-004**: `/llms.txt` is present in the build output and starts with `# Rafael Zago`
 
 ## Assumptions
 

--- a/static/assets/img/flags/br.svg
+++ b/static/assets/img/flags/br.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 14" width="20" height="14" role="img" aria-hidden="true">
+  <rect width="20" height="14" fill="#009b3a"/>
+  <path fill="#fedf00" d="M10 1.5 L18.2 7 L10 12.5 L1.8 7 Z"/>
+  <circle cx="10" cy="7" r="3.2" fill="#002776"/>
+  <path fill="none" stroke="#fff" stroke-width="0.55" d="M7.2 7.9 C8.2 6.3 11.8 6.3 12.8 7.9"/>
+</svg>

--- a/static/assets/img/flags/us.svg
+++ b/static/assets/img/flags/us.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 14" width="20" height="14" role="img" aria-hidden="true">
+  <rect width="20" height="14" fill="#bf0a30"/>
+  <rect y="1.077" width="20" height="1.077" fill="#fff"/>
+  <rect y="3.231" width="20" height="1.077" fill="#fff"/>
+  <rect y="5.385" width="20" height="1.077" fill="#fff"/>
+  <rect y="7.538" width="20" height="1.077" fill="#fff"/>
+  <rect y="9.692" width="20" height="1.077" fill="#fff"/>
+  <rect y="11.846" width="20" height="1.077" fill="#fff"/>
+  <rect width="8" height="7.538" fill="#002868"/>
+</svg>

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,30 @@
+# Rafael Zago
+
+> Blog pessoal bilingue (pt-BR padrão, en em /en/) sobre cloud, DevOps, infraestrutura, Linux, containers, Kubernetes, OpenShift e AI.
+
+Site de notas técnicas de Rafael Zago. Conteúdo em português em /posts/; traduções em inglês em /en/posts/. Use o sitemap e os feeds RSS abaixo para descobrir posts individuais.
+
+## Site
+
+- [Home (pt-BR)](https://www.rafaelvzago.com/): Página inicial em português
+- [Sobre](https://www.rafaelvzago.com/about/): Sobre o autor
+- [Posts](https://www.rafaelvzago.com/posts/): Lista de posts em português
+- [Tags](https://www.rafaelvzago.com/tags/): Arquivo por tags
+- [Busca](https://www.rafaelvzago.com/search/): Busca no site
+- [Home (en)](https://www.rafaelvzago.com/en/): English home page
+- [About (en)](https://www.rafaelvzago.com/en/about/): About the author (English)
+- [Posts (en)](https://www.rafaelvzago.com/en/posts/): English post list
+- [Tags (en)](https://www.rafaelvzago.com/en/tags/): Tag archive (English)
+- [Search (en)](https://www.rafaelvzago.com/en/search/): Site search (English)
+
+## Feeds
+
+- [Sitemap](https://www.rafaelvzago.com/sitemap.xml): Mapa completo de URLs do site
+- [RSS (pt-BR)](https://www.rafaelvzago.com/index.xml): Feed RSS do conteúdo em português
+- [RSS (en)](https://www.rafaelvzago.com/en/index.xml): RSS feed for English content
+
+## Optional
+
+- [GitHub](https://github.com/rafaelvzago): Código e projetos
+- [LinkedIn](https://www.linkedin.com/in/rafaelvzago): Perfil profissional
+- [Twitter](https://twitter.com/rafaelvzago): Conta no X/Twitter


### PR DESCRIPTION
## Summary
- Replace Português/English language switcher labels with Brazil and US SVG flags (accessible via `aria-label`)
- Publish curated `/llms.txt` (llmstxt.org) for AI agents to discover primary pages and feeds
- Update `specs/site-core` for flag switcher and llms.txt requirements

## Test plan
- [ ] http://127.0.0.1:1313/ shows BR/US flags; current language outlined
- [ ] http://127.0.0.1:1313/en/ switches correctly and keeps aria labels
- [ ] Dark mode: flags remain visible with contrast
- [ ] http://127.0.0.1:1313/llms.txt returns Markdown with absolute HTTPS links
- [ ] `make test` passes
- [ ] After merge, https://www.rafaelvzago.com/llms.txt is live


Made with [Cursor](https://cursor.com)